### PR TITLE
Fix regexps to use case-insensitivity correctly

### DIFF
--- a/lib/tzinfo/data/tzdataparser.rb
+++ b/lib/tzinfo/data/tzdataparser.rb
@@ -1072,7 +1072,7 @@ module TZInfo
       attr_reader :operator
       
       def initialize(spec)
-        raise "Invalid on: #{spec}" if spec !~ /^([0-9]+)|(last([A-z]+))|(([A-z]+)([<>]=)([0-9]+))$/
+        raise "Invalid on: #{spec}" if spec !~ /^([0-9]+)|(last([A-Za-z]+))|(([A-Za-z]+)([<>]=)([0-9]+))$/
         
         if $1
           @type = :absolute
@@ -1181,7 +1181,7 @@ module TZInfo
     # @private
     class TZDataFormat #:nodoc:        
       def initialize(spec)
-        if spec =~ /([A-z]+)\/([A-z]+)/
+        if spec =~ /([A-Z]+)\/([A-Z]+)/i
           @type = :alternate
           @standard_abbrev = $1
           @daylight_abbrev = $2

--- a/test/tc_definitions.rb
+++ b/test/tc_definitions.rb
@@ -51,7 +51,7 @@ class TCDefinitions < Minitest::Test
   end
   
   def check_zdump_line(zone, line)
-    if line =~ /\A[^\s]+\s+([A-z][a-z]{2}\s[A-z][a-z]{2}\s+[0-9]+\s[0-9]+:[0-9]+:[0-9]+\s[0-9]+)\s[A-Z]+\s=\s([A-z][a-z]{2}\s[A-z][a-z]{2}\s+[0-9]+\s[0-9]+:[0-9]+:[0-9]+\s[0-9]+)\s([A-Za-z0-9+\-]+)\sisdst=([01])/ then
+    if line =~ /\A[^\s]+\s+([A-Za-z][a-z]{2}\s[A-Za-z][a-z]{2}\s+[0-9]+\s[0-9]+:[0-9]+:[0-9]+\s[0-9]+)\s[A-Z]+\s=\s([A-Za-z][a-z]{2}\s[A-Za-z][a-z]{2}\s+[0-9]+\s[0-9]+:[0-9]+:[0-9]+\s[0-9]+)\s([A-Za-z0-9+\-]+)\sisdst=([01])/ then
       assert_nothing_raised("Exception raised processing line:\n#{line}") do
         utc = yield $1
         local = yield $2


### PR DESCRIPTION
The regexp /[A-z]/ matches all alphabets, but also six non-alphabetic characters, as demonstrated by ("A".."z").to_a.join
=> "ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz"

I've fixed them by using [A-Za-z] instead, or by making the whole regexp case-insensitive. Note that I'm not 100% sure if some of those regexps should actually match the non-alphabets as well (underscore being a possible candidate), so please check that before merging :)
