### PR TITLE
Generate data files with frozen_string_literal: true

### DIFF
--- a/lib/tzinfo/data/tzdataparser.rb
+++ b/lib/tzinfo/data/tzdataparser.rb
@@ -364,6 +364,7 @@ module TZInfo
 
           open_file(File.join(dir, 'countries.rb'), 'w', :external_encoding => 'UTF-8', :universal_newline => true) do |file|
             file.puts('# encoding: UTF-8')
+            file.puts('# frozen_string_literal: true')
             file.puts('')
             file.puts('# This file contains data derived from the IANA Time Zone Database')
             file.puts('# (https://www.iana.org/time-zones).')
@@ -393,6 +394,7 @@ module TZInfo
 
           open_file(File.join(dir, 'timezones.rb'), 'w', :external_encoding => 'UTF-8', :universal_newline => true) do |file|
             file.puts('# encoding: UTF-8')
+            file.puts('# frozen_string_literal: true')
             file.puts('')
             file.puts('# This file contains data derived from the IANA Time Zone Database')
             file.puts('# (https://www.iana.org/time-zones).')
@@ -603,6 +605,7 @@ module TZInfo
           end
 
           file.puts('# encoding: UTF-8')
+          file.puts('# frozen_string_literal: true')
           file.puts('')
           file.puts('# This file contains data derived from the IANA Time Zone Database')
           file.puts('# (https://www.iana.org/time-zones).')


### PR DESCRIPTION
It's not a lot, but some of the strings in these generated files are duplicated and a bit of memory could be saved by enabling `frozen_string_literal`.

There's another source of duplication that could be removed, but not sure if you'd be open to the fix.

For instance:

```ruby
# encoding: UTF-8

# This file contains data derived from the IANA Time Zone Database
# (https://www.iana.org/time-zones).

module TZInfo
  module Data
    module Definitions
      module Cuba
        include TimezoneDefinition
        
        linked_timezone 'Cuba', 'America/Havana'
      end
    end
  end
end
```

Here `"Cuba"` exist twice, one is the backing string for `:Cuba` symbol, because they are automatically casted as `US-ASCII` when applicable:

```ruby
>> Cuba.name.encoding
=> #<Encoding:US-ASCII>
```

So a trick to reduce the memory further could be to set `# encoding: US-ASCII`.