### PR TITLE
Prefer "Türkiye" in `TZInfo::Data::Indexes::Countries`

### DIFF
--- a/lib/tzinfo/data/definitions/Turkey.rb
+++ b/lib/tzinfo/data/definitions/Turkey.rb
@@ -9,7 +9,7 @@ module TZInfo
       module Turkey
         include TimezoneDefinition
         
-        linked_timezone 'Turkey', 'Europe/Istanbul'
+        linked_timezone 'Türkiye', 'Europe/Istanbul'
       end
     end
   end

--- a/lib/tzinfo/data/definitions/Turkey.rb
+++ b/lib/tzinfo/data/definitions/Turkey.rb
@@ -9,7 +9,7 @@ module TZInfo
       module Turkey
         include TimezoneDefinition
         
-        linked_timezone 'Türkiye', 'Europe/Istanbul'
+        linked_timezone 'Turkey', 'Europe/Istanbul'
       end
     end
   end

--- a/lib/tzinfo/data/indexes/countries.rb
+++ b/lib/tzinfo/data/indexes/countries.rb
@@ -819,7 +819,7 @@ module TZInfo
         country 'TO', 'Tonga' do |c|
           c.timezone 'Pacific/Tongatapu', -317, 15, -876, 5
         end
-        country 'TR', 'Turkey' do |c|
+        country 'TR', 'Türkiye' do |c|
           c.timezone 'Europe/Istanbul', 2461, 60, 869, 30
         end
         country 'TT', 'Trinidad & Tobago' do |c|


### PR DESCRIPTION
The English language representation of the country Türkiye changed from "Turkey" to "Türkiye".

This PR changes `TZInfo::Data::Indexes::Countries` to reflect that change.

Context:

- https://turkiye.un.org/en/184798-turkeys-name-changed-t%C3%BCrkiye
- https://www.iso.org/obp/ui/#iso:code:3166:TR
